### PR TITLE
[circuit]: Replace the import source of the `semaphore-noir/.../circuits-noir` with the `"feat/specification-updates_for-using-as-library"` tag of the `masaun/semaphore-noir` repo

### DIFF
--- a/packages/noir/anonymous-group-identity/Nargo.toml
+++ b/packages/noir/anonymous-group-identity/Nargo.toml
@@ -4,7 +4,9 @@ type = "bin"
 
 [dependencies]
 # Semaphore-noir
-semaphore = { path = "../semaphore-noir/circuits-noir" }
+#semaphore = { path = "../semaphore-noir/circuits-noir" }
+semaphore = { tag = "feat/specification-updates_for-using-as-library", git = "https://github.com/masaun/semaphore-noir", directory = "./packages/circuits-noir" }
+
 #semaphore = { tag = "main", git = "https://github.com/hashcloak/semaphore-noir", directory = "./packages/circuits-noir" }
 #semaphore_batch_2_leaves = { tag = "main", git = "https://github.com/hashcloak/semaphore-noir", directory = "./packages/noir-proof-batch/circuits/batch_2_leaves" }
 #semaphore_batch_2_nodes = { tag = "main", git = "https://github.com/hashcloak/semaphore-noir", directory = "./packages/noir-proof-batch/circuits/batch_2_nodes" }


### PR DESCRIPTION
# New import source

- The `masaun/semaphore-noir` repo, which is forked from the original repo:
  - `semaphore-noir/.../circuits-noir` with the `"feat/specification-updates_for-using-as-library"` tag:
       https://github.com/masaun/semaphore-noir/tree/feat/specification-updates_for-using-as-library/packages/circuits-noir